### PR TITLE
fix(server): offline client auto-replace and orphan task agent state cleanup

### DIFF
--- a/.trellis/issues/0015-feat-task-execution-timeout-hang-watchdog.md
+++ b/.trellis/issues/0015-feat-task-execution-timeout-hang-watchdog.md
@@ -1,0 +1,123 @@
+---
+id: 15
+title: "feat(client-node,server): 任务执行超时检测 — Hang Watchdog（第五层防御）"
+status: open
+labels:
+  - enhancement
+  - bug
+  - "priority:P1"
+milestone: null
+author: human
+assignees: []
+relatedIssues:
+  - 13
+relatedFiles:
+  - packages/client-node/src/node.ts
+  - packages/server/src/services/client-service.ts
+  - packages/shared/src/types.ts
+taskRef: null
+githubRef: "blackplume233/AgentDispatch#15"
+closedAs: null
+createdAt: 2026-03-03T00:40:00
+updatedAt: 2026-03-03T00:40:00
+closedAt: null
+---
+
+## 背景
+
+#13 引入的四层防御机制有效解决了 Worker **崩溃**后任务变孤儿的问题。但实际运行中发现了一类新场景：**Worker 进程存活但完全不推进任务**（hang/卡死），四层防御均无法覆盖。
+
+### 复现场景（2026-03-03 实测）
+
+1. 提交 2 个简单 echo 测试任务（tag: `km`, `code`），由 `code-km-p4` OpenCode ACP Worker 认领
+2. Worker 进程存活（PID 可查，内存 ~49MB），但 CPU 使用率为 0
+3. progressMessage 停留在 `"write (in_progress)"` **持续 10+ 分钟**无变化
+4. 手动杀掉 Worker 进程后，Client Node 正确检测到崩溃并重启新 Worker → **Layer 1 自愈生效**
+5. 新 Worker 接手后，同样很快又卡在 `"write (in_progress)"` 不动
+
+### 为什么四层防御无法覆盖
+
+| 防御层 | 触发条件 | 为何不适用 |
+|--------|---------|-----------|
+| **Layer 1 — Client 自愈** | Worker 进程 exit/crash | Worker 进程仍存活，未退出 |
+| **Layer 2 — 熔断器** | 同一 task 被 claim ≥3 次 | 任务仅被 claim 1 次，Worker 未释放 |
+| **Layer 3 — 孤儿对账** | Client 注册/重连时 | Client 正常在线，未重连 |
+| **Layer 4 — Server 交叉校验** | Agent 上报的 currentTaskId ≠ task.claimedBy | Agent 确实在 busy 状态且 taskId 一致 |
+
+## 需求
+
+增加 **Layer 5 — Task Execution Timeout（Hang Watchdog）** 作为最后一道防线。
+
+### 方案设计
+
+#### 5.1 Client-side Watchdog（推荐，更快响应）
+
+在 `ClientNode` 中增加任务执行时间跟踪：
+
+```typescript
+// 新增配置项
+interface ClientConfig {
+  taskTimeout?: {
+    maxExecutionMs?: number;       // 单任务最大执行时间，默认 30 分钟
+    progressStaleMs?: number;      // progress 无更新判定为 stale，默认 10 分钟
+    checkIntervalMs?: number;      // 检查间隔，默认 60 秒
+  };
+}
+```
+
+- 每个 in_progress 任务记录 `lastProgressUpdate` 时间戳
+- 定时检查：如果 `now - lastProgressUpdate > progressStaleMs`，判定为 hang
+- Hang 处理：先尝试 kill Worker 进程触发 Layer 1 自愈；如果 kill 失败，直接调用 `cancel` API
+
+#### 5.2 Server-side Timeout（兜底）
+
+在 `checkHeartbeats` 的 `crossValidateOnlineClients` 中增加超时检查：
+
+```typescript
+// 在 crossValidateOnlineClients 中，对于 agentReportsTaskId === task.id 的情况
+// 增加判断：如果 task.updatedAt 距今超过 maxExecutionMs，force-release
+const lastUpdate = new Date(task.updatedAt).getTime();
+if (now - lastUpdate > serverTaskTimeout) {
+  await this.taskService.forceReleaseTask(task.id, clientId, reason);
+}
+```
+
+#### 5.3 配置项
+
+| 配置项 | 位置 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `taskTimeout.maxExecutionMs` | client.config.json | `1800000` (30min) | 单任务绝对超时 |
+| `taskTimeout.progressStaleMs` | client.config.json | `600000` (10min) | 进度停滞超时 |
+| `taskTimeout.checkIntervalMs` | client.config.json | `60000` (1min) | 检查间隔 |
+| `taskTimeout.maxExecutionMs` | server.config.json | `3600000` (60min) | 服务端兜底超时（应大于客户端） |
+
+### 关键约束
+
+1. **Client 优先，Server 兜底**：Client-side watchdog 响应快（~1min），Server-side 作为最终保障（~60min）
+2. **区分 stale vs slow**：依据 `progressMessage` 或 `updatedAt` 变化判断，而非简单的绝对时间。长时间任务只要有进度更新就不应被超时
+3. **可配置豁免**：某些 capability（如 `ue-heavy`）的任务可能合理地需要更长时间，应支持 per-agent 超时覆盖
+4. **超时后的任务状态**：超时 → force-release → 回到 pending → 可被重新 claim（配合 Layer 2 熔断器防止无限循环）
+5. **日志与告警**：超时事件必须记录 client log（event: `task.timeout.stale_progress`）
+
+## 涉及文件
+
+- `packages/client-node/src/node.ts` — 新增 watchdog timer 和 hang 检测逻辑
+- `packages/server/src/services/client-service.ts` — crossValidateOnlineClients 增加超时判断
+- `packages/shared/src/types.ts` — ClientConfig 新增 `taskTimeout` 字段
+- `packages/client-node/tests/unit/task-robustness.test.ts` — 新增超时相关测试
+
+## 验收标准
+
+- [ ] Worker 进程存活但 progress 停滞超过 `progressStaleMs` 时，Client 自动 kill Worker 并释放任务
+- [ ] 任务执行超过 `maxExecutionMs` 时，Server 兜底 force-release
+- [ ] 超时配置支持 per-agent 覆盖（`agents[].taskTimeout`）
+- [ ] 超时释放的任务回到 pending 可被重新 claim
+- [ ] 配合 Layer 2 熔断器，超时 ≥3 次的任务自动标记 `cancelled`
+- [ ] 有进度更新的长时间任务不被误杀
+- [ ] 新增单元测试覆盖 hang 检测、超时释放、误杀保护场景
+- [ ] client log 记录超时事件
+
+## 补充：测试中发现的其他观察
+
+1. **OpenCode ACP Worker 特定行为**：`code-km-p4` 使用 OpenCode via ACP，频繁卡在 `"write (in_progress)"` 状态。可能是 LLM 请求超时或 ACP stdio 管道阻塞。需要 Worker Manager 层面增加 ACP 连接健康检查。
+2. **之前残留了 13 个 claude-agent-acp 孤儿进程**：Client Node 退出时未正确清理子进程。`GRACEFUL_STOP_TIMEOUT (10s)` 可能不足以等待所有 Worker 退出，建议增加 force-kill 兜底。

--- a/.trellis/issues/0016-bug-multi-slot-shared-workdir-write-deadlock.md
+++ b/.trellis/issues/0016-bug-multi-slot-shared-workdir-write-deadlock.md
@@ -1,0 +1,74 @@
+---
+id: 16
+title: "bug(client-node): 多 slot 共享 workDir 导致 opencode write 工具卡死"
+status: open
+labels:
+  - bug
+  - "priority:P0"
+milestone: null
+author: jiahao
+assignees: []
+relatedIssues: [17]
+relatedFiles:
+  - packages/client-node/src/agents/runtime-agent-config.ts
+  - packages/client-node/src/node.ts
+taskRef: null
+githubRef: null
+closedAs: null
+createdAt: 2026-03-03T01:00:00
+updatedAt: 2026-03-03T01:00:00
+closedAt: null
+---
+
+## 背景
+
+当 `client.config.json` 中配置 `maxConcurrency: 2` 时，`expandWorkerConfig` 将一个 worker 展开为 `code-km-p4:0` 和 `code-km-p4:1` 两个 slot。但两个 slot **共享同一个 `workDir`**，导致两个 opencode 进程在同一工作目录并发运行。
+
+## 复现
+
+1. 配置 `code-km-p4` worker，`maxConcurrency: 2`
+2. 同时提交两个匹配的任务（如 `km` 和 `tapd` 标签）
+3. 两个 slot 各自 claim 一个任务，各启动一个 opencode 进程
+4. 两个 opencode 进程在同一 workDir 中执行，到达 `write` 工具调用时卡死
+
+## 现象
+
+- opencode 的 `write` 工具状态停留在 `in_progress`，永远不报告 `completed`
+- **文件实际已写入磁盘**（时间戳与 `in_progress` 事件精确吻合），但 opencode 进程无法完成后续状态流转
+- 100% 的 write 调用都异常：4 次 write 中 2 次卡死、2 次立即失败后重试再卡死
+- 其他工具（bash、MCP 调用、todowrite、read）全部正常
+
+## 根因分析
+
+两个 opencode 实例共享同一工作目录，opencode 内部的 write 工具在处理文件写入时维护内部状态（文件变更追踪、会话状态等）。当两个进程同时在同一工作目录中执行 write 操作时发生冲突：
+- 一个实例的 write 可能立即失败（检测到冲突）
+- 另一个实例的 write 完成了磁盘写入，但在更新内部状态时死锁
+
+## 修复方案
+
+### 1. `runtime-agent-config.ts` — slot 独立 workDir
+
+`expandWorkerConfig` 为多 slot 生成隔离目录：
+
+```
+baseWorkDir: worker.workDir          // 原始目录（配置/技能源）
+workDir: `${worker.workDir}/slot-${slotIndex}`  // 独立运行目录
+```
+
+单 slot（`maxConcurrency <= 1`）保持原行为，`baseWorkDir === workDir`。
+
+### 2. `node.ts` — 自动准备 slot workDir
+
+在 agent 启动前调用 `prepareSlotWorkDir(cfg)`：
+- 创建 slot 目录
+- 从 baseWorkDir 镜像 junction links（`.claude/`、`.cursor/`、`.kl/` → 同一目标）
+- 复制配置文件（`opencode.json`、`AGENTS.md` 等）
+- 跳过运行时目录（`.dispatch/`、`.local/`、`.artifacts/`）
+
+每个 slot 得到完整的配置环境，技能/规则/MCP 全部可用，且进程状态完全隔离。
+
+## 注意事项
+
+- Windows junction 创建不需要管理员权限（与 symlink 不同）
+- 配置文件是副本，base 更新后需要 config reload 或重启才能同步
+- junction 指向的目录（技能、规则）是透明的，修改源目录立即生效

--- a/.trellis/issues/0017-bug-slot-busy-status-desync-after-server-cancel.md
+++ b/.trellis/issues/0017-bug-slot-busy-status-desync-after-server-cancel.md
@@ -1,0 +1,70 @@
+---
+id: 17
+title: "bug(client-node+server): server 取消/释放任务后 slot 忙碌状态不同步"
+status: open
+labels:
+  - bug
+  - "priority:P1"
+milestone: null
+author: jiahao
+assignees: []
+relatedIssues: [16]
+relatedFiles:
+  - packages/client-node/src/node.ts
+  - packages/server/src/services/client-service.ts
+taskRef: null
+githubRef: null
+closedAs: null
+createdAt: 2026-03-03T01:00:00
+updatedAt: 2026-03-03T01:00:00
+closedAt: null
+---
+
+## 背景
+
+当 admin 通过 server API 执行 `force-release` 或 `cancel` 操作后，client-node 的 worker manager 无法感知任务状态变化，继续通过 heartbeat 上报旧的 busy 状态。
+
+## 复现
+
+1. Worker slot 正在执行一个任务（status=busy, currentTaskId=xxx）
+2. Admin 通过 `POST /api/v1/tasks/:id/force-release` 或 `cancel` 取消任务
+3. Server 侧任务变为 `pending` 或 `cancelled`
+4. Client-node 不知道，heartbeat 继续上报 slot 为 busy
+
+## 现象
+
+- Server 中 client 记录的 agent 状态显示 `busy`，但关联的任务已经是 `pending`/`cancelled`
+- Dashboard 显示 slot 忙碌，实际已经没有有效任务在执行
+- 如果使用 `force-release`（回到 pending），poller 会重新 claim 该任务，形成无限循环
+- 必须手动杀进程才能恢复 slot 为 idle
+
+## 根因
+
+1. **client-node 缺少反向对账**：heartbeat 只发送状态，不校验 server 侧任务是否仍然有效
+2. **server 缺少纠正逻辑**：收到 heartbeat 中 agent 声称的 `currentTaskId` 时，不校验该任务是否仍处于活跃状态
+
+## 修复方案
+
+### 1. Client 侧：`reconcileStaleWorkers()`（`node.ts`）
+
+在 `doHeartbeat` 成功后调用：
+- 遍历所有 busy worker
+- 对每个 busy worker，向 server 查询其 `currentTaskId` 的任务状态
+- 如果任务已是终态（cancelled/completed/failed）或不再属于本 client：
+  - 停止对应 agent 进程
+  - 回收 worker token
+  - 标记 slot 为 idle
+  - 清理 outputDir/inputDir
+
+### 2. Server 侧：`reconcileStaleAgentClaims()`（`client-service.ts`）
+
+在 `checkHeartbeats` 周期中增加反向校验：
+- 遍历所有在线 client 的 agent 列表
+- 如果某个 agent 的 `currentTaskId` 不在活跃任务集中（即任务已完成/取消/失败），主动将该 agent 状态修正为 idle 并清除 `currentTaskId`
+
+### 设计考量
+
+- Client 侧修复是**主要修复**：能停止实际的 agent 进程并释放资源
+- Server 侧修复是**防御性兜底**：在 client 未及时自愈时纠正存储的状态
+- Client 侧每个 heartbeat 增加 N 个 HTTP 请求（N = busy worker 数，通常 0-2）
+- Server 侧增加一轮 O(agents) 遍历 + Set 查找，开销很小

--- a/packages/server/src/services/client-service.ts
+++ b/packages/server/src/services/client-service.ts
@@ -68,10 +68,24 @@ export class ClientService {
 
     const existing = await this.findByName(dto.name);
     if (existing) {
-      throw new ConflictError(
-        ErrorCode.CLIENT_ALREADY_REGISTERED,
-        `Client with name "${dto.name}" already registered`,
-      );
+      if (existing.status === 'offline') {
+        await this.queue.enqueue({
+          type: 'client.replace_offline',
+          execute: async () => {
+            await this.store.delete(existing.id);
+          },
+        });
+        this.logger.info('Replaced offline client with same name', {
+          category: 'client',
+          event: 'client.replaced_offline',
+          context: { oldId: existing.id, name: dto.name },
+        });
+      } else {
+        throw new ConflictError(
+          ErrorCode.CLIENT_ALREADY_REGISTERED,
+          `Client with name "${dto.name}" already registered`,
+        );
+      }
     }
 
     const now = new Date().toISOString();
@@ -262,6 +276,8 @@ export class ClientService {
       return offlineSet.has(claimClientId) || !knownClientIds.has(claimClientId);
     });
 
+    const releasedByClient = new Map<string, string[]>();
+
     for (const task of orphanedTasks) {
       const clientId = task.claimedBy?.clientId ?? '';
       const reason = knownClientIds.has(clientId)
@@ -274,11 +290,61 @@ export class ClientService {
           event: 'task.released.auto',
           context: { taskId: task.id, clientId, reason },
         });
+        const agentId = task.claimedBy?.agentId;
+        if (agentId) {
+          const list = releasedByClient.get(clientId) ?? [];
+          list.push(agentId);
+          releasedByClient.set(clientId, list);
+        }
       } catch {
         this.logger.warn('Failed to release orphaned task', {
           category: 'task',
           event: 'task.release.failed',
           context: { taskId: task.id, clientId },
+        });
+      }
+    }
+
+    await this.cleanupAgentStateAfterRelease(releasedByClient);
+  }
+
+  private async cleanupAgentStateAfterRelease(
+    releasedByClient: Map<string, string[]>,
+  ): Promise<void> {
+    for (const [clientId, agentIds] of releasedByClient) {
+      try {
+        const client = await this.store.get(clientId);
+        if (!client) continue;
+
+        const agentIdSet = new Set(agentIds);
+        let needsUpdate = false;
+        const updatedAgents = client.agents.map((agent) => {
+          if (agentIdSet.has(agent.id) && (agent.status === 'busy' || agent.currentTaskId)) {
+            needsUpdate = true;
+            return { ...agent, status: 'idle' as const, currentTaskId: undefined };
+          }
+          return agent;
+        });
+
+        if (needsUpdate) {
+          const updated: Client = { ...client, agents: updatedAgents };
+          await this.queue.enqueue({
+            type: 'client.cleanup_agents',
+            execute: async () => {
+              await this.store.save(updated);
+            },
+          });
+          this.logger.info('Cleaned up agent state after orphan task release', {
+            category: 'client',
+            event: 'agent.state_cleaned',
+            context: { clientId, agentIds },
+          });
+        }
+      } catch {
+        this.logger.warn('Failed to clean up agent state', {
+          category: 'client',
+          event: 'agent.cleanup_failed',
+          context: { clientId },
         });
       }
     }


### PR DESCRIPTION
## Summary

- **Offline client auto-replace**: When a client registers with the same name as an existing offline client, automatically delete the stale record and allow re-registration instead of throwing `CLIENT_ALREADY_REGISTERED` error. This resolves the common scenario where a ClientNode restarts and cannot re-register because its old offline record still exists.
- **Orphan task agent state cleanup**: After `releaseOrphanedTasks()` releases tasks from offline/unknown clients, also reset the associated agent state (set to `idle`, clear `currentTaskId`) to prevent stale busy status from persisting in the client record.

## Changes

| File | Change |
|------|--------|
| `packages/server/src/services/client-service.ts` | Modified `register()` to auto-replace offline clients; added `cleanupAgentStateAfterRelease()` method |
| `.trellis/issues/0015-*` | Issue: task execution timeout hang watchdog (Layer 5 defense) |
| `.trellis/issues/0016-*` | Issue: multi-slot shared workDir write deadlock |
| `.trellis/issues/0017-*` | Issue: slot busy status desync after server cancel |

## Context

These fixes address two pain points discovered during production deployment:

1. **ClientNode restart failure** — After a ClientNode goes offline and restarts, re-registration fails because the old record (status=offline) still exists. The fix checks if the existing client is offline and auto-replaces it.
2. **Stale agent busy status** — When orphaned tasks are released during heartbeat checks, the agents that were executing those tasks remain in `busy` status with a stale `currentTaskId`. The new `cleanupAgentStateAfterRelease()` method resets these agents to `idle`.

## Test plan

- [x] Server builds successfully after rebase onto latest master (`565c651`)
- [ ] ClientNode registers successfully when previous offline record exists
- [ ] Agent state is correctly reset to idle after orphan task release
- [ ] Online clients with same name still correctly throw conflict error
